### PR TITLE
store.find(['exists', 'unknown'])

### DIFF
--- a/lib/find.js
+++ b/lib/find.js
@@ -4,7 +4,10 @@ var findOne = require('./utils/find-one')
 var findMany = require('./utils/find-many')
 
 module.exports = function find (objectsOrIds) {
-  var state = { db: this.db }
+  var state = {
+    db: this.db,
+    errors: this.PouchDB.Errors
+  }
   var isArray = Array.isArray(objectsOrIds)
 
   return isArray ? findMany(state, objectsOrIds) : findOne(state, objectsOrIds)

--- a/lib/utils/find-many.js
+++ b/lib/utils/find-many.js
@@ -9,10 +9,17 @@ module.exports = function findMany (state, idsOrObjects) {
   return state.db.allDocs({keys: ids, include_docs: true})
 
   .then(function (response) {
-    return response.rows.reduce(function (docs, row) {
-      var index = ids.indexOf(row.id)
-      docs[index] = row.doc
-      return docs
-    }, []).map(toObject)
+    var foundMap = response.rows.reduce(function (map, row) {
+      map[row.id] = row.doc
+      return map
+    }, {})
+    var docs = ids.map(function (id) {
+      var doc = foundMap[id]
+      if (doc) return doc
+
+      return state.errors.MISSING_DOC
+    })
+
+    return docs.map(toObject)
   })
 }

--- a/tests/specs/find.js
+++ b/tests/specs/find.js
@@ -52,27 +52,6 @@ test('store.find(object)', function (t) {
   })
 })
 
-test('store.find(array)', function (t) {
-  t.plan(2)
-
-  var db = dbFactory()
-  var store = new Store(db)
-
-  store.add([
-    { id: 'foo' },
-    { id: 'bar' }
-  ])
-
-  .then(function () {
-    return store.find(['foo', {id: 'bar'}])
-  })
-
-  .then(function (objects) {
-    t.is(objects[0].id, 'foo', 'resolves value')
-    t.is(objects[1].id, 'bar', 'resolves value')
-  })
-})
-
 test('store.find fails for non-existing', function (t) {
   t.plan(4)
 
@@ -97,5 +76,26 @@ test('store.find fails for non-existing', function (t) {
   .catch(function (err) {
     t.ok(err instanceof Error, 'rejects error')
     t.is(err.status, 404)
+  })
+})
+
+test('store.find(array)', function (t) {
+  t.plan(2)
+
+  var db = dbFactory()
+  var store = new Store(db)
+
+  store.add([
+    { id: 'foo' },
+    { id: 'bar' }
+  ])
+
+  .then(function () {
+    return store.find(['foo', {id: 'bar'}])
+  })
+
+  .then(function (objects) {
+    t.is(objects[0].id, 'foo', 'resolves value')
+    t.is(objects[1].id, 'bar', 'resolves value')
   })
 })

--- a/tests/specs/find.js
+++ b/tests/specs/find.js
@@ -99,3 +99,23 @@ test('store.find(array)', function (t) {
     t.is(objects[1].id, 'bar', 'resolves value')
   })
 })
+
+test('store.find(array) with non-existing', function (t) {
+  t.plan(2)
+
+  var db = dbFactory()
+  var store = new Store(db)
+
+  store.add([
+    { id: 'exists' }
+  ])
+
+  .then(function () {
+    return store.find(['exists', 'unknown'])
+  })
+
+  .then(function (objects) {
+    t.is(objects[0].id, 'exists', 'resolves with value for existing')
+    t.is(objects[1].status, 404, 'resolves with 404 error for unknown')
+  })
+})


### PR DESCRIPTION
`store.find(array)` now always resolves with an array of the same
length as the passed `array`. For objects that could not be found,
PouchDB's `MISSING_DOC` error is passed.

fixes #8 
