### PR TITLE
refactor(findOrAdd): externalizing internal utils methods

### DIFF
--- a/lib/find-or-add.js
+++ b/lib/find-or-add.js
@@ -1,10 +1,7 @@
 'use strict'
 
-var toId = require('./utils/to-id')
-var findOne = require('./utils/find-one')
-var addOne = require('./utils/add-one')
-var findMany = require('./utils/find-many')
-var addMany = require('./utils/add-many')
+var findOrAddOne = require('./utils/find-or-add-one')
+var findOrAddMany = require('./utils/find-or-add-many')
 
 module.exports = function findOrAdd (idOrObjectOrArray, newObject) {
   var state = {
@@ -15,57 +12,4 @@ module.exports = function findOrAdd (idOrObjectOrArray, newObject) {
   var isArray = Array.isArray(idOrObjectOrArray)
 
   return isArray ? findOrAddMany(state, idOrObjectOrArray) : findOrAddOne(state, idOrObjectOrArray, newObject)
-}
-
-function findOrAddMany (state, passedObjects) {
-  var foundObjects
-  var passedObjectIds = passedObjects.map(toId)
-
-  return findMany(state, passedObjectIds)
-
-  .then(function (_foundObjects) {
-    foundObjects = _foundObjects
-
-    var foundObjectIds = foundObjects.map(toId)
-    var notFoundObjects = passedObjects.reduce(function (notFoundObjects, passedObject) {
-      if (foundObjectIds.indexOf(passedObject.id) === -1) {
-        notFoundObjects.push(passedObject)
-      }
-      return notFoundObjects
-    }, [])
-
-    return addMany(state, notFoundObjects)
-  })
-
-  .then(function (addedObjects) {
-    var objects = []
-
-    foundObjects.concat(addedObjects).forEach(function (object) {
-      var index = passedObjectIds.indexOf(object.id)
-      objects[index] = object
-    })
-
-    return objects
-  })
-}
-
-function findOrAddOne (state, idOrObject, newObject) {
-  var id = toId(idOrObject)
-
-  if (!id) return state.Promise.reject(state.errors.MISSING_ID)
-
-  if (idOrObject === id && !newObject) {
-    return state.Promise.reject(state.errors.MISSING_ID)
-  }
-
-  return findOne(state, id)
-  .catch(function (/*error*/) {
-    if (typeof newObject === 'object') {
-      newObject.id = id
-    } else {
-      newObject = idOrObject
-    }
-
-    return addOne(state, newObject)
-  })
 }

--- a/lib/utils/find-or-add-many.js
+++ b/lib/utils/find-or-add-many.js
@@ -1,0 +1,35 @@
+var toId = require('./to-id')
+var findMany = require('./find-many')
+var addMany = require('./add-many')
+
+module.exports = function findOrAddMany (state, passedObjects) {
+  var foundObjects
+  var passedObjectIds = passedObjects.map(toId)
+
+  return findMany(state, passedObjectIds)
+
+  .then(function (_foundObjects) {
+    foundObjects = _foundObjects
+
+    var foundObjectIds = foundObjects.map(toId)
+    var notFoundObjects = passedObjects.reduce(function (notFoundObjects, passedObject) {
+      if (foundObjectIds.indexOf(passedObject.id) === -1) {
+        notFoundObjects.push(passedObject)
+      }
+      return notFoundObjects
+    }, [])
+
+    return addMany(state, notFoundObjects)
+  })
+
+  .then(function (addedObjects) {
+    var objects = []
+
+    foundObjects.concat(addedObjects).forEach(function (object) {
+      var index = passedObjectIds.indexOf(object.id)
+      objects[index] = object
+    })
+
+    return objects
+  })
+}

--- a/lib/utils/find-or-add-one.js
+++ b/lib/utils/find-or-add-one.js
@@ -1,0 +1,24 @@
+var toId = require('./to-id')
+var findOne = require('./find-one')
+var addOne = require('./add-one')
+
+module.exports = function findOrAddOne (state, idOrObject, newObject) {
+  var id = toId(idOrObject)
+
+  if (!id) return state.Promise.reject(state.errors.MISSING_ID)
+
+  if (idOrObject === id && !newObject) {
+    return state.Promise.reject(state.errors.MISSING_ID)
+  }
+
+  return findOne(state, id)
+  .catch(function (/*error*/) {
+    if (typeof newObject === 'object') {
+      newObject.id = id
+    } else {
+      newObject = idOrObject
+    }
+
+    return addOne(state, newObject)
+  })
+}


### PR DESCRIPTION
moving `findOrAddOne` and `findOrAddMany` into `./lib/utils`, as we do it in all other places.
