### PR TITLE
Speeding up standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,15 +56,11 @@
     "prepublish": "semantic-release pre",
     "pretest:browser:cloud": "npm run build",
     "pretest:browser:local": "npm run build",
-    "test": "standard && npm run -s test:node | tap-spec",
+    "standard": "standard *.js bin/*.js helpers/*.js tests/*.js utils/*.js",
+    "test": "npm run standard && npm run -s test:node | tap-spec",
     "test:browser:cloud": "zuul -- tests",
     "test:browser:local": "zuul --local 8080 -- tests",
     "test:coverage": "istanbul cover tests && istanbul-coveralls",
     "test:node": "node tests"
-  },
-  "standard": {
-    "ignore": [
-      "dist/**"
-    ]
   }
 }


### PR DESCRIPTION
Even with dist & docs added to standard.ignore, standards run for **0m16.950s**. By configuring only the files we want to be checked, which should techically be the same, time is down to **0m0.999s**
