### PR TITLE
fix: use eventify internally to avoid extra events

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npm install pouchdb
 npm install pouchdb-hoodie-api
 ```
 
-### Inlcuding the plugin
+### Including the plugin
 
 #### With browserify or on node.js/io.js
 

--- a/find-or-add.js
+++ b/find-or-add.js
@@ -16,6 +16,6 @@ module.exports = findOrAdd
  */
 function findOrAdd (idOrObjectOrArray, newObject) {
   return Array.isArray(idOrObjectOrArray) ?
-    findOrAddMany.call(this, idOrObjectOrArray) :
-    findOrAddOne.call(this, idOrObjectOrArray, newObject)
+    findOrAddMany.call(this, null, idOrObjectOrArray) :
+    findOrAddOne.call(this, null, idOrObjectOrArray, newObject)
 }

--- a/helpers/find-or-add-many.js
+++ b/helpers/find-or-add-many.js
@@ -1,8 +1,9 @@
 var toId = require('../utils/to-id')
 var findMany = require('./find-many')
 var addMany = require('./add-many')
+var eventify = require('./eventify')
 
-module.exports = function findOrAddMany (passedObjects) {
+module.exports = function findOrAddMany (state, passedObjects) {
   var self = this
   var foundObjects
   var passedObjectIds = passedObjects.map(toId)
@@ -19,6 +20,10 @@ module.exports = function findOrAddMany (passedObjects) {
       }
       return notFoundObjects
     }, [])
+
+    if (state) {
+      return eventify(self, state, addMany)(notFoundObjects)
+    }
 
     return addMany.call(self, notFoundObjects)
   })

--- a/helpers/find-or-add-one.js
+++ b/helpers/find-or-add-one.js
@@ -1,8 +1,9 @@
 var toId = require('../utils/to-id')
 var findOne = require('./find-one')
 var addOne = require('./add-one')
+var eventify = require('./eventify')
 
-module.exports = function findOrAddOne (idOrObject, newObject) {
+module.exports = function findOrAddOne (state, idOrObject, newObject) {
   var self = this
   var Promise = this.constructor.utils.Promise
   var errors = this.constructor.Errors
@@ -23,6 +24,10 @@ module.exports = function findOrAddOne (idOrObject, newObject) {
       newObject.id = id
     } else {
       newObject = idOrObject
+    }
+
+    if (state) {
+      return eventify(self, state, addOne)(newObject)
     }
 
     return addOne.call(self, newObject)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function hoodieApi (options) {
     add: eventify(this, state, require('./add')),
     find: require('./find').bind(this),
     findAll: require('./find-all').bind(this),
-    findOrAdd: eventify(this, state, require('./find-or-add')),
+    findOrAdd: require('./lib/find-or-add-with-events').bind(this, state),
     update: eventify(this, state, require('./update')),
     updateOrAdd: eventify(this, state, require('./update-or-add')),
     updateAll: eventify(this, state, require('./update-all')),

--- a/lib/find-or-add-with-events.js
+++ b/lib/find-or-add-with-events.js
@@ -1,0 +1,12 @@
+'use strict'
+
+var findOrAddOne = require('../helpers/find-or-add-one')
+var findOrAddMany = require('../helpers/find-or-add-many')
+
+module.exports = findOrAdd
+
+function findOrAdd (state, idOrObjectOrArray, newObject) {
+  return Array.isArray(idOrObjectOrArray) ?
+    findOrAddMany.call(this, state, idOrObjectOrArray) :
+    findOrAddOne.call(this, state, idOrObjectOrArray, newObject)
+}

--- a/tests/specs/find-or-add.js
+++ b/tests/specs/find-or-add.js
@@ -186,3 +186,39 @@ test('#58 store.findOrAdd([object1, object2]) triggers no events when finds exis
     t.is(triggeredEvents, 2, 'triggers only one event, make sure add still works')
   })
 })
+
+test('findOrAdd() as required by end user', function (t) {
+  t.plan(5)
+
+  var PouchDB = process.browser ? global.PouchDB : require('pouchdb')
+
+  PouchDB.plugin({
+    findOrAdd: require('../../find-or-add')
+  })
+
+  var options = process.browser ? {
+    adapter: 'memory'
+  } : {
+    db: require('memdown')
+  }
+
+  var db = new PouchDB('db-findOrAdd-as-required', options)
+
+  t.isNot(PouchDB.prototype.findOrAdd, 'undefined', 'check findOrAdd plugin is active')
+
+  db.findOrAdd('findOrAddOne', {foo: 'baz'})
+
+  .then(function (object) {
+    t.is(object.id, 'findOrAddOne', 'resolves with id')
+    t.is(object.foo, 'baz', 'resolves with new object')
+  })
+
+  db.findOrAdd([
+    {id: 'findOrAddMany', foo: 'bar'}
+  ])
+  .then(function (objects) {
+    t.is(objects[0].id, 'findOrAddMany', 'object1 to be created')
+    t.is(objects[0].foo, 'bar', 'object1 to be created')
+  })
+
+})

--- a/tests/specs/find-or-add.js
+++ b/tests/specs/find-or-add.js
@@ -123,7 +123,7 @@ test('store.findOrAdd([object1, object2])', function (t) {
   })
 })
 
-test.skip('#58 store.findOrAdd(id, object) triggers no events when finds existing', function (t) {
+test('#58 store.findOrAdd(id, object) triggers no events when finds existing', function (t) {
   t.plan(2)
 
   var db = dbFactory()
@@ -153,7 +153,7 @@ test.skip('#58 store.findOrAdd(id, object) triggers no events when finds existin
   })
 })
 
-test.skip('#58 store.findOrAdd([object1, object2]) triggers no events when finds existing', function (t) {
+test('#58 store.findOrAdd([object1, object2]) triggers no events when finds existing', function (t) {
   t.plan(2)
 
   var db = dbFactory()

--- a/tests/specs/update-or-add.js
+++ b/tests/specs/update-or-add.js
@@ -126,7 +126,7 @@ test('store.updateOrAdd(array) updates existing, adds new', function (t) {
   })
 })
 
-test.skip('#58 store.updateOrAdd(id, object) triggers no extra events', function (t) {
+test('#58 store.updateOrAdd(id, object) triggers no extra events', function (t) {
   t.plan(2)
 
   var db = dbFactory()


### PR DESCRIPTION
Allows users to require() the findOrAdd, and have events.
