### PR TITLE
48 allow update before remove

### DIFF
--- a/remove.js
+++ b/remove.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var markAsDeleted = require('./utils/mark-as-deleted')
+
 var updateOne = require('./helpers/update-one')
 var updateMany = require('./helpers/update-many')
 
@@ -8,12 +10,13 @@ module.exports = remove
 /**
  * removes existing object
  *
- * @param  {Object|Function} change   changed properties or function that
- *                                    alters passed object
+ * @param  {Object|Function} objectsOrIds   id or object with `.id` property
+ * @param  {Object|Function} [change]       Change properties or function that
+ *                                          changes existing object
  * @return {Promise}
  */
-function remove (objectsOrIds) {
+function remove (objectsOrIds, change) {
   return Array.isArray(objectsOrIds) ?
-    updateMany.call(this, objectsOrIds, {_deleted: true}) :
-    updateOne.call(this, objectsOrIds, {_deleted: true})
+    updateMany.call(this, objectsOrIds.map(markAsDeleted.bind(null, change))) :
+    updateOne.call(this, markAsDeleted(change, objectsOrIds))
 }

--- a/tests/specs/remove.js
+++ b/tests/specs/remove.js
@@ -114,7 +114,7 @@ test('store.remove(array) removes existing, returns error for non-existing', fun
   })
 })
 
-test.skip('store.remove([changedObjects]) updates before removing', function (t) {
+test('store.remove([changedObjects]) updates before removing', function (t) {
   t.plan(4)
 
   var db = dbFactory()
@@ -144,7 +144,7 @@ test.skip('store.remove([changedObjects]) updates before removing', function (t)
   })
 })
 
-test.skip('store.remove(changedObject) updates before removing', function (t) {
+test('store.remove(changedObject) updates before removing', function (t) {
   t.plan(2)
 
   var db = dbFactory()
@@ -165,7 +165,7 @@ test.skip('store.remove(changedObject) updates before removing', function (t) {
   })
 })
 
-test.skip('store.remove(id, changedProperties) updates before removing', function (t) {
+test('store.remove(id, changedProperties) updates before removing', function (t) {
   t.plan(2)
 
   var db = dbFactory()
@@ -186,7 +186,7 @@ test.skip('store.remove(id, changedProperties) updates before removing', functio
   })
 })
 
-test.skip('remove(id, changeFunction) updates before removing', function (t) {
+test('remove(id, changeFunction) updates before removing', function (t) {
   t.plan(2)
 
   var db = dbFactory()

--- a/utils/mark-as-deleted.js
+++ b/utils/mark-as-deleted.js
@@ -1,0 +1,15 @@
+'use strict'
+
+var extend = require('pouchdb-extend')
+var changeObject = require('./change-object')
+
+// Normalizes objectOrId, applies changes if any, and mark as deleted
+module.exports = function markAsDeleted (change, objectOrId) {
+  var object = typeof objectOrId === 'string' ? { id: objectOrId } : objectOrId
+
+  if (change) {
+    changeObject(change, object)
+  }
+
+  return extend({_deleted: true}, object)
+}


### PR DESCRIPTION
Here is how I thought to solve this problem:
- If a change object or function was passed into `remove`, then `remove` will either extend it with a the property `_deleted: true`, or put a thin wrapper around it, which appends the `_deleted: true` property to the object before it gets passed into the actual change function.
- If no change arguments were passed, then `_deleted: true` will be appended to each of the `objectsOrIds` before they are sent off to the update functions without the change parameters, allowing them to update and 'delete' properly.

I also updated the function signature to accept an optional change argument and made changes to the documentation to reflect that.

closes #48
