### PR TITLE
fix: add more browsers to test in

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,11 +1,15 @@
 ui: tape
 browsers:
   - name: chrome
-    version: [36, 37, 39, 41]
+    version: '34..latest'
   - name: firefox
-    version: [31, latest]
+    version: '29..latest'
   - name: safari
-    version: 6
+    version: '7..latest'
+  - name: iPhone
+    version: '7.0..latest'
+  - name: android
+    version: '4.3..latest'
 scripts:
   - './node_modules/pouchdb/dist/pouchdb.js'
   - './node_modules/pouchdb/dist/pouchdb.memory.js'


### PR DESCRIPTION
Based upon the browsers we want to support: http://docs.hood.ie/en/hoodieverse/system-requirements-browser-compatibilities-prerequisites-before-getting-started-with-hoodie.html

Does not add IE as our tests wont run on IE for some reason.

:baby_chick: 
