### PR TITLE
tests: enable android 4.0+ and iOS7+

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -6,10 +6,10 @@ browsers:
     version: '29..latest'
   - name: safari
     version: '7..latest'
-  - name: iPhone
+  - name: iphone
     version: '7.0..latest'
   - name: android
-    version: '4.3..latest'
+    version: '4.0..latest'
 scripts:
   - './node_modules/pouchdb/dist/pouchdb.js'
   - './node_modules/pouchdb/dist/pouchdb.memory.js'

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ PouchDB.plugin({
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/hoodie-pouch.svg)](https://saucelabs.com/u/hoodie-pouch)
 
-_Test are currently not running on >IE10 and mobile Safari. This is likely an error with the setup and we would be more than happy if you'd want to fix that :)_
+_Tests are currently not running on >IE10 however once https://github.com/pouchdb/pouchdb/pull/4220 lands we can enable this._
 
 ### In Node.js
 


### PR DESCRIPTION
These can be merged while we wait for the patch in PouchDB since they're not blocked.
